### PR TITLE
correção da funcao FileToBase64 para deletar arquivo temporário

### DIFF
--- a/Demo/uFraMensagens.pas
+++ b/Demo/uFraMensagens.pas
@@ -1472,6 +1472,7 @@ begin
       result := Memo1.text;
     finally
       outStream.Free;
+      DeleteFile(ExtractFilePath(Application.ExeName) + AOutFileName );
     end;
   finally
     inStream.Free;


### PR DESCRIPTION
correção da função. deletando arquivo após gerado o stream.