### PR TITLE
Fix: Cast pointer to NativeUInt to prevent 64-bit Range Check Errors

### DIFF
--- a/Source/Services/uTWPPConnect.languages.pas
+++ b/Source/Services/uTWPPConnect.languages.pas
@@ -78,7 +78,7 @@ var
   POldProtect: DWORD;
 begin
   VirtualProtect(xOldResourceString, SizeOf(xOldResourceString^), PAGE_EXECUTE_READWRITE, @POldProtect);
-  xOldResourceString^.Identifier := Integer(xValueChanged);
+  xOldResourceString^.Identifier := NativeUInt(xValueChanged);
   VirtualProtect(xOldResourceString,SizeOf(xOldResourceString^),POldProtect, @POldProtect);
 end;
 


### PR DESCRIPTION
Fixed an issue where injecting resource strings caused intermittent `ERangeError` exceptions in 64-bit builds. 


In TTranslatorInject.SetResourceString, the pointer xValueChanged (PChar) was being cast to a 32-bit Integer. In 64-bit environments, memory addresses frequently exceed the 32-bit limit, causing a Range Check Error (ERangeError) when the pointer value is too large to fit in an Integer.

